### PR TITLE
wait for user input

### DIFF
--- a/main.go
+++ b/main.go
@@ -559,4 +559,7 @@ func main() {
 	}
 	fmt.Println()
 	fmt.Printf("Benchmark results saved to %s\n", LogFileName)
+
+	fmt.Println("Press 'Enter' to exit...")
+	fmt.Scanln()
 }


### PR DESCRIPTION
Wait for user input before finishing execution, to prevent automatically closing the script.